### PR TITLE
Corrections to remove `location` calls from InstanceDescriptor objects

### DIFF
--- a/Lib/designspaceProblems/problems.py
+++ b/Lib/designspaceProblems/problems.py
@@ -79,6 +79,7 @@ class DesignSpaceProblem(object):
         (3,8):  "missing output path",
         (3,10): "no instances defined",
         (3,11): "no instances defined for discrete location",
+        (3,12): "illegal value in discrete axis",
 
         # 4 glyphs
         (4,0): 'different number of contours in glyph',


### PR DESCRIPTION
Fixes #15

This PR removes calls to `location` for InstanceDescriptor objects, opting for either calling `getFullDesignLocation` or `getFullUserLocation` (item 2 in the issue)

It also makes sure the error for "illegal value in discrete axis" is tagged correctly with "sources" or "instances" (item 1 in the issue).

I did not attempt to fix item 3 in the issue (the duplicate calls because of `checkInstances` being called once per discrete location) because I felt like I didn't fully understand the logic, but I can certainly do so if you think it should be fixed.

Thanks!