### PR TITLE
Rephrase Feature error message and provide more details

### DIFF
--- a/Lib/designspaceProblems/__init__.py
+++ b/Lib/designspaceProblems/__init__.py
@@ -792,8 +792,8 @@ class DesignSpaceChecker(object):
                     if isinstance(element, featureElements.FeatureBlock):
                         if element.name in countedFeaturesTags:
                             countedFeaturesTags[element.name] += 1
-            except Exception:
-                self.problems.append(DesignSpaceProblem(8,0))
+            except Exception as err:
+                self.problems.append(DesignSpaceProblem(8,0, details=str(err)))
 
         sourceCount = len(self.ds.fonts)
         for tag, value in countedFeaturesTags.items():
@@ -805,6 +805,7 @@ class DesignSpaceChecker(object):
                 continue
             else:
                 self.problems.append(DesignSpaceProblem(8,1, data=dict(feature=tag)))
+
 
 
 if __name__ == "__main__":
@@ -821,3 +822,4 @@ if __name__ == "__main__":
     print(dc.discreteLocationAsString({'countedItems': 1.0, 'outlined': 0.0}))
     print(dc.discreteLocationAsString())
     print(dc.discreteLocationAsString({}))
+

--- a/Lib/designspaceProblems/problems.py
+++ b/Lib/designspaceProblems/problems.py
@@ -125,7 +125,7 @@ class DesignSpaceProblem(object):
         (7,11): 'condition with missing maximum',
 
         # 8 features
-        (8,0): 'source feature file corrupt',
+        (8,0): 'problem parsing the feature file',
         (8,1): 'source is missing feature'
     }
 

--- a/problems.md
+++ b/problems.md
@@ -113,5 +113,5 @@
 
 ## 8. features
 
-  * `8.0	source feature file corrupt`
+  * `8.0	problem parsing the feature file`
   * `8.1	source is missing feature`


### PR DESCRIPTION
When checking the features, designspaceproblems tries to compile the features with FontTools FeaLib. This adds the error message to the Problem.details so we might learn something from this downstream.

The error message is rephrased into "problem parsing the feature file". File corruption is a different problem. We can read the file, but the parser is confused about it.

Separate question: is it useful to check the features as part of the designspaceproblems. One example at hand shows that FeaLib triggers an exception in data that otherwise compiles into a font.