### PR TITLE
Add detailed glyph compatibility checks (4.3, 4.4, 4.5, 4.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ Lib/designspaceProblems/_version.py
 
 tests/20190324 ufolib issue
 tests/_*
+
+# Virtual environment
+venv/
+
+# IDE
+.vscode/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+defcon[lxml]>=0.6.0
+fontMath>=0.4.9
+fontParts>=0.8.2
+fontPens>=0.2.4
+fontTools[ufo,lxml]>=3.32.0
+mutatorMath>=2.1.2
+ufoProcessor>=1.0


### PR DESCRIPTION
Implement per-contour validation that was previously only listed as comments:

  - 4.3: Different number of on-curve points on contour
  - 4.4: Different number of off-curve points on contour
  - 4.5: Curve has wrong type (line vs curve vs qcurve)
  - 4.8: Contour has wrong direction

  Changes

  Lib/designspaceProblems/init.py
  - Add parseDigestContours() helper to extract per-contour statistics from glyph digest
  - Add getContourDirection() helper using shoelace formula to detect contour winding
  - Extend checkGlyph() to collect and compare contour stats across masters
  - Report each problem once per contour (avoid duplicates when multiple masters differ)

  requirements.txt
  - Add project dependencies (was empty): defcon, fontMath, fontParts, fontPens, fontTools, mutatorMath, ufoProcessor

  .gitignore
  - Add venv/ and .vscode/